### PR TITLE
v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "addrindexrs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addrindexrs"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Roman Zeyde <me@romanzey.de>", "kenshin-samourai <kenshin_samourai@tutanota.com>"]
 description = "An efficient address indexer in Rust"
 license = "MIT"

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,11 +3,27 @@
 
 ## Releases ##
 
+- [v0.4.4](#0_4_4)
 - [v0.4.3](#0_4_3)
 - [v0.4.0](#0_4_0)
 - [v0.3.0](#0_3_0)
 - [v0.2.0](#0_2_0)
 - [v0.1.0](#0_1_0)
+
+<a name="0_4_4"/>
+
+## addrindexrs v0.4.4 ##
+
+### Change log ###
+
+- `--backend-connect` also accepts hostnames and not just IPs.
+- Build Docker image on every push and publish on release.
+
+#### Credits ###
+
+- Warren Puffet
+- Adam Krellenstein
+- Ouziel Slama
 
 <a name="0_4_3"/>
 


### PR DESCRIPTION
- `--backend-connect` also accepts hostnames and not just IPs.
- Build Docker image on every push and publish on release.