### PR TITLE
Accept `main` and `test` for Network, like `bitcoind` and `counterparty-server`

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -37,7 +37,7 @@ doc = "JSONRPC authentication cookie ('USER:PASSWORD', default: read from ~/.bit
 name = "network"
 type = "crate::config::BitcoinNetwork"
 convert_into = "::bitcoin::network::constants::Network"
-doc = "Select Bitcoin network type ('mainnet', 'testnet' or 'regtest')"
+doc = "Select Bitcoin network type ('mainnet', 'main', 'testnet', 'test', or 'regtest')"
 default = "Default::default()"
 
 [[param]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,11 @@ impl FromStr for BitcoinNetwork {
     type Err = <Network as FromStr>::Err;
 
     fn from_str(string: &str) -> std::result::Result<Self, Self::Err> {
-        Network::from_str(string).map(BitcoinNetwork)
+        match string {
+            "main" => Network::from_str("bitcoin").map(BitcoinNetwork),
+            "test" => Network::from_str("testnet").map(BitcoinNetwork),
+            _ => Network::from_str(string).map(BitcoinNetwork),
+        }
     }
 }
 


### PR DESCRIPTION
comes with https://github.com/CounterpartyXCP/counterparty-core/pull/1548/commits/ddd4d1ee380afa69a8df828086c99379948498f5
so we can use one env variable to run test node:

```
NETWORK=test  docker compose up -d
```
